### PR TITLE
Enable nodejs18

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ The following table lists the release version of this repo together with the ver
 - `nodejs16.x` (v3.x)
 - `nodejs18.x` (v3.2+)
 
+Note that to use `nodejs18` you will need to build this Layer using the `public.ecr.aws/lambda/nodejs:18` Docker image, as it is not currently possible to get `node18` installed on the standard Amazon Linux 2 distros, see https://github.com/nodesource/distributions/issues/1381
 
 ## Contributions
 If you would like to contribute to this repository, please open an issue or submit a PR.

--- a/README.md
+++ b/README.md
@@ -73,11 +73,13 @@ The following table lists the release version of this repo together with the ver
 |   2.0.0 | 0.29.1 |  8.11.3 |  1.12.0 |   1.2.1 |    1.0.8 |     14 |
 |   3.0.0 | 0.30.7 |  8.12.2 |  1.12.0 |   1.2.4 |    1.0.8 |     16 |
 |   3.1.0 | 0.30.7 |  8.12.2 |  1.12.0 |   1.2.4 |    1.0.8 |     16 |
+|   3.2.0 | 0.30.7 |  8.12.2 |  1.12.0 |   1.2.4 |    1.0.8 |     18 |
 
 ### CompatibleRuntimes
 - `nodejs12.x` (v1.x)
 - `nodejs14.x` (v2.x)
 - `nodejs16.x` (v3.x)
+- `nodejs18.x` (v3.2+)
 
 
 ## Contributions

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sharp-heic-lambda-layer",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "Lambda Layer providing sharp with HEIC support",
   "main": "index.js",
   "scripts": {

--- a/template.yaml
+++ b/template.yaml
@@ -26,6 +26,7 @@ Resources:
       CompatibleRuntimes:
         - nodejs14.x
         - nodejs16.x
+        - nodejs18.x
       LicenseInfo: 'MIT'
       RetentionPolicy: Retain
     Metadata:


### PR DESCRIPTION
Enable `node18` support by adding to the list of "CompatibleRuntimes"

I have tested this branch using AWS Lambda with node18 and it works for me.

Node18 was released for lambda on 18 NOV 2022 
https://aws.amazon.com/blogs/compute/node-js-18-x-runtime-now-available-in-aws-lambda/

You can't build this on the standard AL2 image (e.g. `aws/codebuild/amazonlinux2-x86_64-standard`), as node18 won't build on there, but you can build this on the `public.ecr.aws/lambda/nodejs:18` image. I have added a note to the README about this issue.