### PR TITLE
Make layer name configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ sam deploy --guided
 |      SAM_BUCKET |      yes |                         | Name of S3 Bucket to store layer              |
 |       S3_PREFIX |       no | sharp-heic-lambda-layer | Prefix within S3 Bucket to store layer        |
 |      STACK_NAME |       no | sharp-heic-lambda-layer | Name of CloudFormation stack                  |
+|      LAYER_NAME |       no |              sharp-heic | Name of layer                                 |
 |      AWS_REGION |       no |               us-east-1 | AWS Region to deploy to                       |
 | ORGANIZATION_ID |       no |                    none | ID of Organization to grant access to layer   |
 |       PRINCIPAL |       no |                 account | Principal to grant access to layer            |

--- a/deployment/createSAMConfiguration.js
+++ b/deployment/createSAMConfiguration.js
@@ -2,6 +2,7 @@
 
 const region = process.env.AWS_REGION || 'us-east-1';
 const stackName = process.env.STACK_NAME || 'sharp-heic-lambda-layer';
+const layerName = process.env.LAYER_NAME || 'sharp-heic';
 const samBucket = process.env.SAM_BUCKET;
 const s3Prefix = process.env.S3_PREFIX || 'sharp-heic-lambda-layer';
 const organizationId = process.env.ORGANIZATION_ID || 'none';
@@ -18,10 +19,11 @@ region = "${region}"
 output_template_file = "${packagedTemplate}"
 [default.deploy.parameters]
 stack_name = "${stackName}"
+layer_name = "${layerName}"
 s3_bucket = "${samBucket}"
 s3_prefix = "${s3Prefix}"
 region = "${region}"
 capabilities = "CAPABILITY_IAM"
-parameter_overrides = "OrganizationId=${organizationId} Principal=${principal}"
+parameter_overrides = "OrganizationId=${organizationId} Principal=${principal} LayerName=${layerName}"
 template_file  = "${packagedTemplate}"
 `);

--- a/template.yaml
+++ b/template.yaml
@@ -11,6 +11,10 @@ Parameters:
     Default: account
     Description: An account ID, or * to grant permission to use the layer to all AWS accounts.
     Type: String
+  LayerName:
+    Default: sharp-heic
+    Description: The name of the Lambda Layer that will be created.
+    Type: String
 
 Conditions:
   NoOrganizationId: !Equals [ !Ref OrganizationId, none ]
@@ -20,7 +24,7 @@ Resources:
   SharpHEICLayer:
     Type: AWS::Serverless::LayerVersion
     Properties:
-      LayerName: sharp-heic
+      LayerName: !Ref LayerName
       Description: Sharp Layer with HEIC Support
       ContentUri: ./layer/
       CompatibleRuntimes:


### PR DESCRIPTION
I needed the layer name to be configurable so I could build multiple versions of it in my AWS account to fit with my multi-environment release pipeline.

This change works for me, but I might have missed something. 